### PR TITLE
Fix duplicate task (de)serializing, adapt array/quote notation

### DIFF
--- a/action.php
+++ b/action.php
@@ -69,7 +69,7 @@ switch ($data->action) {
         if (get_config('block_massaction', 'duplicatemaxactivities') < count($modulerecords)) {
             $duplicatetask = new duplicate_task();
             $duplicatetask->set_userid($USER->id);
-            $duplicatetask->set_custom_data(array("modules" => $modulerecords));
+            $duplicatetask->set_custom_data(['modules' => $modulerecords]);
             \core\task\manager::queue_adhoc_task($duplicatetask);
             redirect($returnurl, get_string('backgroundtaskinformation', 'block_massaction'), null,
                 \core\output\notification::NOTIFY_SUCCESS);
@@ -101,7 +101,7 @@ switch ($data->action) {
         if (get_config('block_massaction', 'duplicatemaxactivities') < count($modulerecords)) {
             $duplicatetask = new duplicate_task();
             $duplicatetask->set_userid($USER->id);
-            $duplicatetask->set_custom_data(array("modules" => $modulerecords, "sectionid" => $data->duplicateToTarget));
+            $duplicatetask->set_custom_data(['modules' => $modulerecords, 'sectionid' => $data->duplicateToTarget]);
             \core\task\manager::queue_adhoc_task($duplicatetask);
             redirect($returnurl, get_string('backgroundtaskinformation', 'block_massaction'), null,
                 \core\output\notification::NOTIFY_SUCCESS);

--- a/classes/task/duplicate_task.php
+++ b/classes/task/duplicate_task.php
@@ -48,7 +48,7 @@ class duplicate_task extends \core\task\adhoc_task {
      */
     public function execute() {
         $data = $this->get_custom_data();
-        $sectionid = empty($data["sectionid"]) ? false : $data["sectionid"];
-        actions::duplicate((array) $data["modules"], $sectionid);
+        $sectionid = empty($data->sectionid) ? false : $data->sectionid;
+        actions::duplicate((array) $data->modules, $sectionid);
     }
 }


### PR DESCRIPTION
cb5e4332390a1b2a557903563d7caa88259b08b1 introduced a bug preventing the `duplicate_task` to properly deserialize the module records to be duplicated. As a consequence the task failed completely.

In addition to that I unified the syntax a little bit