### PR TITLE
Restrict 39_311_stable branch to corresponding moodle versions

### DIFF
--- a/version.php
+++ b/version.php
@@ -24,8 +24,10 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2022031500;
+$plugin->version = 2022041700;
 $plugin->requires  = 2020061500;
+$plugin->supported = [39, 311];
+$plugin->incompatible = 400;
 $plugin->component = 'block_massaction';
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = 'v6.0.0';
+$plugin->release = 'v6.0.1';


### PR DESCRIPTION
We should restrict the `39_311_stable` branch to the corresponding moodle versions. I also bumped up version for a release which includes the Mac OS fix.