### PR TITLE
Bump version for 4.0 release

### DIFF
--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2022031500;
-$plugin->requires  = 2021052500;
+$plugin->version = 2022041700;
+$plugin->requires  = 2022041900;
 $plugin->component = 'block_massaction';
-$plugin->maturity = MATURITY_ALPHA;
+$plugin->maturity = MATURITY_STABLE;
 $plugin->release = 'v7.0.0';


### PR DESCRIPTION
For the 7.0.0 release of the plugin I added the requirement for the current moodle 4.0 release version. Ideally, we could pull a release before the official moodle 4.0 release (April 19th) to acquire the early bird badge, of course only, if we do not find any bugs while testing.

@Syxton 
Speaking of testing: I cannot run behat tests in my dev environment currently in 4.0 for some reason I cannot tell (https://github.com/moodlehq/moodle-docker/issues/207). Can you doublecheck if the tests are passing in an environment with all course formats installed we are currently trying to support? Maybe even after merging #22? :-) Thanks in advance!

BTW: I tested basic formats topics, weekly and topcoll manually. Onetopic and tiles are still pretty buggy but have not been updated to 4.0 yet anyway, so users trying to use this ATM have other problems than block_massaction :-) Or let's say: It's basically working, but drag&drop support throws a lot of errors. We could leave both as supported plugins as I'm pretty  confident that we won't have many problems with that as soon as the plugin maintainers have fixed them, but if you prefer to drop it for the moment, I'm also happy with that.