### PR TITLE
mustache: Update context comment to use {title}

### DIFF
--- a/templates/duplicateto_select.mustache
+++ b/templates/duplicateto_select.mustache
@@ -19,12 +19,12 @@
     Data attributes required for JS:
     * none
     Context variables required for this template:
-    * number, name
+    * number, title
     Example context (json):
     {
         "sections": {
             "number": "0",
-            "name": "Test"
+            "title": "Test"
         }      
     }
 }}
@@ -36,6 +36,6 @@
         {{#str}} action_duplicatetosection, block_massaction {{/str}}
     </option>
     {{#sections}}
-        <option value="{{number}}" label="{{title}}">{{title}}</option>
+        <option value="{{number}}">{{title}}</option>
     {{/sections}}
 </select>&nbsp;

--- a/templates/moveto_select.mustache
+++ b/templates/moveto_select.mustache
@@ -19,12 +19,12 @@
     Data attributes required for JS:
     * none
     Context variables required for this template:
-    * number, name
+    * number, title
     Example context (json):
     {
         "sections": {
             "number": "0",
-            "name": "Test"
+            "title": "Test"
         }      
     }
 }}
@@ -36,6 +36,6 @@
         {{#str}} action_movetosection, block_massaction {{/str}}
     </option>
     {{#sections}}
-        <option value="{{number}}" label="{{title}}">{{title}}</option>
+        <option value="{{number}}">{{title}}</option>
     {{/sections}}
 </select>&nbsp;

--- a/templates/section_select.mustache
+++ b/templates/section_select.mustache
@@ -19,12 +19,12 @@
     Data attributes required for JS:
     * none
     Context variables required for this template:
-    * number, name
+    * number, title
     Example context (json):
     {
         "sections": {
             "number": "0",
-            "name": "Test"
+            "title": "Test"
         }      
     }
 }}
@@ -35,9 +35,7 @@
         {{#str}} selectallinsection, block_massaction {{/str}}
     </option>
     {{#sections}}
-        <option id="block-massaction-control-section-list-select-option-{{number}}"
-                value="{{number}}"
-                label="{{title}}">
+        <option id="block-massaction-control-section-list-select-option-{{number}}" value="{{number}}">
             {{title}}
         </option>
     {{/sections}}


### PR DESCRIPTION
I noticed you were trying to fix the mustache files and I think I figured out the issue. The context comments in the mustache files had a different structure than the data you were using, so the mustache files worked fine in Behat and live testing, but failed in mustache linting (which uses the comment's data structure instead of the real data structure). Please triple check that it's still working in live, because I only tested against the GitHub action.