### PR TITLE
Remove obsolete aria-label attributes

### DIFF
--- a/templates/duplicateto_select.mustache
+++ b/templates/duplicateto_select.mustache
@@ -29,10 +29,8 @@
     }
 }}
 <select id="block-massaction-control-section-list-duplicateto"
-        name="{{#str}} action_duplicatetosection, block_massaction {{/str}}"
-        aria-label="{{#str}} action_duplicatetosection, block_massaction {{/str}}">
-    <option value="{{#str}} action_duplicatetosection, block_massaction {{/str}}"
-        aria-label="{{#str}} action_duplicatetosection, block_massaction {{/str}}">
+        name="{{#str}} action_duplicatetosection, block_massaction {{/str}}">
+    <option value="{{#str}} action_duplicatetosection, block_massaction {{/str}}">
         {{#str}} action_duplicatetosection, block_massaction {{/str}}
     </option>
     {{#sections}}

--- a/templates/moveto_select.mustache
+++ b/templates/moveto_select.mustache
@@ -29,10 +29,8 @@
     }
 }}
 <select id="block-massaction-control-section-list-moveto"
-        name="{{#str}} action_movetosection, block_massaction {{/str}}"
-        aria-label="{{#str}} action_movetosection, block_massaction {{/str}}">
-    <option value="{{#str}} action_movetosection, block_massaction {{/str}}"
-        aria-label="{{#str}} action_movetosection, block_massaction {{/str}}">
+        name="{{#str}} action_movetosection, block_massaction {{/str}}">
+    <option value="{{#str}} action_movetosection, block_massaction {{/str}}">
         {{#str}} action_movetosection, block_massaction {{/str}}
     </option>
     {{#sections}}

--- a/templates/section_select.mustache
+++ b/templates/section_select.mustache
@@ -29,9 +29,8 @@
     }
 }}
 <select id="block-massaction-control-section-list-select"
-        name="{{#str}} selectallinsection, block_massaction {{/str}}"
-        aria-label="{{#str}} selectallinsection, block_massaction {{/str}}">
-    <option value="description" aria-label="{{#str}} selectallinsection, block_massaction {{/str}}">
+        name="{{#str}} selectallinsection, block_massaction {{/str}}">
+    <option value="description">
         {{#str}} selectallinsection, block_massaction {{/str}}
     </option>
     {{#sections}}


### PR DESCRIPTION
Following the suggestion of @jrchamp at https://github.com/Syxton/moodle-block_massaction/pull/26#issuecomment-1102712615