### PR TITLE
Fix check for applicable formats

### DIFF
--- a/block_massaction.php
+++ b/block_massaction.php
@@ -94,7 +94,7 @@ class block_massaction extends block_base {
         if ($this->page->user_is_editing()) {
 
             $applicableformatkey = 'course-view-' . $COURSE->format;
-            $iscoursecompatible = in_array($applicableformatkey, $this->applicable_formats())
+            $iscoursecompatible = in_array($applicableformatkey, array_keys($this->applicable_formats()))
                 && $this->applicable_formats()[$applicableformatkey];
             if (!$iscoursecompatible) {
                     $this->content = new stdClass();


### PR DESCRIPTION
There currently is a wrong check for showing the block content. This does not really hurt any functionality because the first part (the wrong one) of the expression always evaluates to true. This only triggers a debugger warning if the second part tries to access a non existing array key in case we have not defined the current course format in `applicable_formats`. However, this should be fixed.

Thanks @sh-csg for spotting and reporting this!

