### PR TITLE
Backport to 3.9-3.11: Fix check for applicable formats 

### DIFF
--- a/block_massaction.php
+++ b/block_massaction.php
@@ -90,7 +90,7 @@ class block_massaction extends block_base {
         if ($this->page->user_is_editing()) {
 
             $applicableformatkey = 'course-view-' . $COURSE->format;
-            $iscoursecompatible = in_array($applicableformatkey, $this->applicable_formats())
+            $iscoursecompatible = in_array($applicableformatkey, array_keys($this->applicable_formats()))
                 && $this->applicable_formats()[$applicableformatkey];
             if (!$iscoursecompatible) {
                     $this->content = new stdClass();


### PR DESCRIPTION
This backports #38 to the `39_311_stable` branch