### PR TITLE
Ensure there is only one block instance on a page

### DIFF
--- a/block_massaction.php
+++ b/block_massaction.php
@@ -103,6 +103,23 @@ class block_massaction extends block_base {
                     return $this->content;
             }
 
+            // Check for double instances. This usually should not be an issue, but in rare cases users manage to add
+            // two blocks to the site.
+            $massactionblockscount = 0;
+            foreach ($this->page->blocks->get_regions() as $region) {
+                foreach ($this->page->blocks->get_blocks_for_region($region) as $block) {
+                    if ($block instanceof block_massaction) {
+                        $massactionblockscount++;
+                    }
+                    if ($massactionblockscount > 1) {
+                        $this->content = new stdClass();
+                        $this->content->text = get_string('multipleinstances', 'block_massaction');
+                        $this->content->footer = '';
+                        return $this->content;
+                    }
+                }
+            }
+
             // Initialize the JS module.
             $this->page->requires->js_call_amd('block_massaction/massactionblock', 'init');
 

--- a/lang/en/block_massaction.php
+++ b/lang/en/block_massaction.php
@@ -60,6 +60,8 @@ $string['invalidcourseid'] = 'Invalid course ID';
 $string['jsonerror'] = 'Error coding: Invalid JSON format';
 $string['modulename'] = 'Activity name';
 $string['moduletype'] = 'Activity type';
+$string['multipleinstances'] = 'There must not be multiple instances of this block on the same page. '
+    . 'Please remove additional instances.';
 $string['noitemselected'] = 'Please select at least one item to apply the mass-action';
 $string['noaction'] = 'No action specified';
 $string['noactionsavailable'] = 'You do not have the permissions to execute any of the possible operations this block is providing';


### PR DESCRIPTION
Closes #42 

In rare cases users manage to add two blocks to a page despite block API saying this is not allowed.

For example: Load same course in two tabs, click "Add block" in both tabs. Then add a block in the first, after that in the second tab. Voilà: you got two block instances :-)

This also can happen when two editing teachers add a block at the same time, of course.

This PR does not prevent that issue (which has to be fixed in moodle core in my opinion). However: The block now refuses to display if it detects more than one instance of the massaction block on the current page displaying an error message to the user.

This PR could theoretically be backported to `39_311_stable` if necessary. However, to keep up the compatibility with moodle 3.9 stable including PHP <7.4 we would have to replace the array filtering ;-)