### PR TITLE
Fix alignment of action links

### DIFF
--- a/templates/block_massaction.mustache
+++ b/templates/block_massaction.mustache
@@ -72,7 +72,7 @@
     <div class="block-massaction-action">
         {{#actions}}
             <div id="block-massaction-action-{{action}}">
-                <button class="btn btn-link btn-sm">
+                <button class="btn btn-link btn-sm text-left">
                     {{#pix}} {{icon}}, moodle, {{actiontext}} {{/pix}}&nbsp;{{actiontext}}
                 </button>
             </div>


### PR DESCRIPTION
Closes #46

Same screenshot than in #46 after patch:

![grafik](https://user-images.githubusercontent.com/65113153/178332810-27301772-ecad-4126-b361-67edb473b78e.png)
