### PR TITLE
Update ci.yml environmental requirements for 4.1+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:10
+        image: postgres:12
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'


### PR DESCRIPTION
MDL-71747 - changes environmental requirements.  
This commit bumps the postgres version for automated testing to v12 from v10.  Fixes the failed master tests.