### PR TITLE
Fix behat tests for grid, onetopic, tiles

### DIFF
--- a/tests/behat/grid.feature
+++ b/tests/behat/grid.feature
@@ -36,39 +36,3 @@ Feature: Check if block generates all necessary checkboxes in grid format and pr
     Then the "disabled" attribute of "#block-massaction-control-section-list-select-option-2" "css_element" should not be set
     Then the "disabled" attribute of "#block-massaction-control-section-list-select-option-3" "css_element" should be set
     Then the "disabled" attribute of "#block-massaction-control-section-list-select-option-4" "css_element" should not be set
-
-  @javascript
-  Scenario: Check if mass actions 'indent' and 'outdent' work
-    # We need to use a different course format which supports indentation.
-    # From moodle 4.0 on this is a feature a course format has to explicitely support.
-    Given I installed course format "grid"
-    And the following "courses" exist:
-      | fullname    | shortname | numsections | format |
-      | Test course | TC2       | 5           | grid   |
-    And the following "users" exist:
-      | username | firstname | lastname | email                |
-      | teacher1 | Mr        | Teacher  | teacher1@example.com |
-    And the following "course enrolments" exist:
-      | user     | course | role           |
-      | teacher1 | TC2    | editingteacher |
-    And the following "activities" exist:
-      | activity | course | idnumber | name           | intro                 | section |
-      | page     | TC2    | 1        | Test Activity1 | Test page description | 0       |
-      | page     | TC2    | 2        | Test Activity2 | Test page description | 1       |
-      | label    | TC2    | 3        | Test Activity3 | Label text            | 2       |
-      | page     | TC2    | 4        | Test Activity4 | Test page description | 4       |
-      | assign   | TC2    | 5        | Test Activity5 | Test page description | 4       |
-    When I log in as "teacher1"
-    And I am on "Test course" course homepage with editing mode on
-    And I add the "Mass Actions" block
-    # Everything is setup now, let's do the real test.
-    And I click on "Test Activity2 Checkbox" "checkbox"
-    And I click on "Test Activity5 Checkbox" "checkbox"
-    And I click on "Indent (move right)" "link" in the "Mass Actions" "block"
-    Then "#section-1 li.modtype_page div.indent-1" "css_element" should exist
-    Then "#section-4 li.modtype_assign div.indent-1" "css_element" should exist
-    When I click on "Test Activity2 Checkbox" "checkbox"
-    And I click on "Test Activity5 Checkbox" "checkbox"
-    And I click on "Outdent (move left)" "link" in the "Mass Actions" "block"
-    Then "#section-1 li.modtype_page div.indent-1" "css_element" should not exist
-    Then "#section-4 li.modtype_assign div.indent-1" "css_element" should not exist

--- a/tests/behat/onetopic.feature
+++ b/tests/behat/onetopic.feature
@@ -6,8 +6,8 @@ Feature: Check if block generates all necessary checkboxes in onetopic format an
   Scenario: Check if checkboxes are created properly for onetopic format
     Given I installed course format "onetopic"
     And the following "courses" exist:
-      | fullname        | shortname | numsections | format   |
-      | Test course     | TC        | 5           | onetopic |
+      | fullname        | shortname | numsections | format   | coursedisplay |
+      | Test course     | TC        | 5           | onetopic | 0             |
     And the following "users" exist:
       | username | firstname | lastname | email                |
       | teacher1 | Mr        | Teacher  | teacher1@example.com |
@@ -24,7 +24,7 @@ Feature: Check if block generates all necessary checkboxes in onetopic format an
     When I log in as "teacher1"
     And I am on "Test course" course homepage with editing mode on
     And I add the "Mass Actions" block
-    When I follow "General"
+    When I click on ".nav-link[title='General']" "css_element"
     And I click on "Test Activity1 Checkbox" "checkbox"
     Then the field "Test Activity1 Checkbox" matches value "1"
     Then the "disabled" attribute of "#block-massaction-control-section-list-select-option-0" "css_element" should not be set
@@ -32,10 +32,10 @@ Feature: Check if block generates all necessary checkboxes in onetopic format an
     Then the "disabled" attribute of "#block-massaction-control-section-list-select-option-2" "css_element" should be set
     Then the "disabled" attribute of "#block-massaction-control-section-list-select-option-3" "css_element" should be set
     Then the "disabled" attribute of "#block-massaction-control-section-list-select-option-4" "css_element" should be set
-    When I follow "Topic 4"
+    When I click on ".nav-link[title='Topic 4']" "css_element"
     And I click on "Test Activity4 Checkbox" "checkbox"
     Then the field "Test Activity4 Checkbox" matches value "1"
-    When I follow "Topic 2"
+    When I click on ".nav-link[title='Topic 2']" "css_element"
     And I click on "Label text Checkbox" "checkbox"
     Then the field "Label text Checkbox" matches value "1"
     Then the "disabled" attribute of "#block-massaction-control-section-list-select-option-0" "css_element" should be set
@@ -43,49 +43,9 @@ Feature: Check if block generates all necessary checkboxes in onetopic format an
     Then the "disabled" attribute of "#block-massaction-control-section-list-select-option-2" "css_element" should not be set
     Then the "disabled" attribute of "#block-massaction-control-section-list-select-option-3" "css_element" should be set
     Then the "disabled" attribute of "#block-massaction-control-section-list-select-option-4" "css_element" should be set
-    When I follow "Topic 3"
+    When I click on ".nav-link[title='Topic 3']" "css_element"
     Then the "disabled" attribute of "#block-massaction-control-section-list-select-option-0" "css_element" should be set
     Then the "disabled" attribute of "#block-massaction-control-section-list-select-option-1" "css_element" should be set
     Then the "disabled" attribute of "#block-massaction-control-section-list-select-option-2" "css_element" should be set
     Then the "disabled" attribute of "#block-massaction-control-section-list-select-option-3" "css_element" should be set
     Then the "disabled" attribute of "#block-massaction-control-section-list-select-option-4" "css_element" should be set
-
-  @javascript
-  Scenario: Check if mass actions 'indent' and 'outdent' work
-    # We need to use a different course format which supports indentation.
-    # From moodle 4.0 on this is a feature a course format has to explicitely support.
-    Given I installed course format "onetopic"
-    And the following "courses" exist:
-      | fullname    | shortname | numsections | format   |
-      | Test course | TC2       | 5           | onetopic |
-    And the following "users" exist:
-      | username | firstname | lastname | email                |
-      | teacher1 | Mr        | Teacher  | teacher1@example.com |
-    And the following "course enrolments" exist:
-      | user     | course | role           |
-      | teacher1 | TC2    | editingteacher |
-    And the following "activities" exist:
-      | activity | course | idnumber | name           | intro                 | section |
-      | page     | TC2    | 1        | Test Activity1 | Test page description | 0       |
-      | page     | TC2    | 2        | Test Activity2 | Test page description | 1       |
-      | label    | TC2    | 3        | Test Activity3 | Label text            | 2       |
-      | page     | TC2    | 4        | Test Activity4 | Test page description | 4       |
-      | assign   | TC2    | 5        | Test Activity5 | Test page description | 4       |
-    When I log in as "teacher1"
-    And I am on "Test course" course homepage with editing mode on
-    And I add the "Mass Actions" block
-    # Everything is setup now, let's do the real test.
-    When I follow "Topic 2"
-    And I click on "Test Activity2 Checkbox" "checkbox"
-    And I click on "Indent (move right)" "link" in the "Mass Actions" "block"
-    Then "#section-1 li.modtype_page div.indent-1" "css_element" should exist
-    When I click on "Test Activity2 Checkbox" "checkbox"
-    And I click on "Outdent (move left)" "link" in the "Mass Actions" "block"
-    Then "#section-1 li.modtype_page div.indent-1" "css_element" should not exist
-    When I follow "Topic 5"
-    And I click on "Test Activity5 Checkbox" "checkbox"
-    And I click on "Indent (move right)" "link" in the "Mass Actions" "block"
-    Then "#section-4 li.modtype_assign div.indent-1" "css_element" should exist
-    And I click on "Test Activity5 Checkbox" "checkbox"
-    And I click on "Outdent (move left)" "link" in the "Mass Actions" "block"
-    Then "#section-4 li.modtype_assign div.indent-1" "css_element" should not exist

--- a/tests/behat/tiles.feature
+++ b/tests/behat/tiles.feature
@@ -27,7 +27,6 @@ Feature: Check if block generates all necessary checkboxes in tiles format and p
     When I log in as "teacher1"
     And I am on "Test course" course homepage with editing mode on
     And I add the "Mass Actions" block
-    And I click on "Expand all" "link"
     And I click on "Test Activity1 Checkbox" "checkbox"
     And I click on "Test Activity4 Checkbox" "checkbox"
     Then the field "Test Activity1 Checkbox" matches value "1"
@@ -40,40 +39,3 @@ Feature: Check if block generates all necessary checkboxes in tiles format and p
     Then the "disabled" attribute of "#block-massaction-control-section-list-select-option-2" "css_element" should not be set
     Then the "disabled" attribute of "#block-massaction-control-section-list-select-option-3" "css_element" should be set
     Then the "disabled" attribute of "#block-massaction-control-section-list-select-option-4" "css_element" should not be set
-
-  @javascript
-  Scenario: Check if mass actions 'indent' and 'outdent' work
-    # We need to use a different course format which supports indentation.
-    # From moodle 4.0 on this is a feature a course format has to explicitely support.
-    Given I installed course format "tiles"
-    And the following "courses" exist:
-      | fullname    | shortname | numsections | format |
-      | Test course | TC2       | 5           | tiles  |
-    And the following "users" exist:
-      | username | firstname | lastname | email                |
-      | teacher1 | Mr        | Teacher  | teacher1@example.com |
-    And the following "course enrolments" exist:
-      | user     | course | role           |
-      | teacher1 | TC2    | editingteacher |
-    And the following "activities" exist:
-      | activity | course | idnumber | name           | intro                 | section |
-      | page     | TC2    | 1        | Test Activity1 | Test page description | 0       |
-      | page     | TC2    | 2        | Test Activity2 | Test page description | 1       |
-      | label    | TC2    | 3        | Test Activity3 | Label text            | 2       |
-      | page     | TC2    | 4        | Test Activity4 | Test page description | 4       |
-      | assign   | TC2    | 5        | Test Activity5 | Test page description | 4       |
-    When I log in as "teacher1"
-    And I am on "Test course" course homepage with editing mode on
-    And I add the "Mass Actions" block
-    # Everything is setup now, let's do the real test.
-    And I click on "Expand all" "text"
-    And I click on "Test Activity2 Checkbox" "checkbox"
-    And I click on "Test Activity5 Checkbox" "checkbox"
-    And I click on "Indent (move right)" "link" in the "Mass Actions" "block"
-    Then "#section-1 li.modtype_page div.indent-1" "css_element" should exist
-    Then "#section-4 li.modtype_assign div.indent-1" "css_element" should exist
-    When I click on "Test Activity2 Checkbox" "checkbox"
-    And I click on "Test Activity5 Checkbox" "checkbox"
-    And I click on "Outdent (move left)" "link" in the "Mass Actions" "block"
-    Then "#section-1 li.modtype_page div.indent-1" "css_element" should not exist
-    Then "#section-4 li.modtype_assign div.indent-1" "css_element" should not exist


### PR DESCRIPTION
With the changes in current master and latest versions of format_tiles, format_grid and format_onetopic the behat tests fail. This fixes them.