### PR TITLE
tests: define class properties (PHP 8.2)

### DIFF
--- a/tests/massaction_test.php
+++ b/tests/massaction_test.php
@@ -38,6 +38,16 @@ use restore_controller_exception;
  */
 class massaction_test extends advanced_testcase {
     /**
+     * @var stdClass Course record.
+     */
+    private $course;
+
+    /**
+     * @var stdClass User record.
+     */
+    private $teacher;
+
+    /**
      * Prepare testing.
      */
     public function setUp(): void {


### PR DESCRIPTION
 Creation of dynamic properties is deprecated in PHP 8.2 and will be removed in a future release.