### PR TITLE
Issue #102 Fix move/duplicate error when target is not chosen

### DIFF
--- a/templates/duplicateto_select.mustache
+++ b/templates/duplicateto_select.mustache
@@ -25,13 +25,13 @@
         "sections": {
             "number": "0",
             "title": "Test"
-        }      
+        }
     }
 }}
 <select id="block-massaction-control-section-list-duplicateto"
         name="target_section_duplicating"
         aria-label="{{#str}} action_duplicatetosection, block_massaction {{/str}}">
-    <option value="{{#str}} action_duplicatetosection, block_massaction {{/str}}">
+    <option value="">
         {{#str}} action_duplicatetosection, block_massaction {{/str}}
     </option>
     {{#sections}}

--- a/templates/moveto_select.mustache
+++ b/templates/moveto_select.mustache
@@ -25,13 +25,13 @@
         "sections": {
             "number": "0",
             "title": "Test"
-        }      
+        }
     }
 }}
 <select id="block-massaction-control-section-list-moveto"
         name="target_section_moving"
         aria-label="{{#str}} action_movetosection, block_massaction {{/str}}">
-    <option value="{{#str}} action_movetosection, block_massaction {{/str}}">
+    <option value="">
         {{#str}} action_movetosection, block_massaction {{/str}}
     </option>
     {{#sections}}


### PR DESCRIPTION
Fix the issue #102

The issue is checking empty value in the error check but actual value is not empty when target is not chosen.

https://github.com/Syxton/moodle-block_massaction/blob/bfe404ea5734d89ff774e0c44e9b93498e16f70c/amd/src/massactionblock.js#L204
