### PR TITLE
Issue #103 Fix escaped text in dropdown

### DIFF
--- a/templates/duplicateto_select.mustache
+++ b/templates/duplicateto_select.mustache
@@ -35,6 +35,6 @@
         {{#str}} action_duplicatetosection, block_massaction {{/str}}
     </option>
     {{#sections}}
-        <option value="{{number}}">{{title}}</option>
+        <option value="{{number}}">{{{title}}}</option>
     {{/sections}}
 </select>

--- a/templates/moveto_select.mustache
+++ b/templates/moveto_select.mustache
@@ -35,6 +35,6 @@
         {{#str}} action_movetosection, block_massaction {{/str}}
     </option>
     {{#sections}}
-        <option value="{{number}}">{{title}}</option>
+        <option value="{{number}}">{{{title}}}</option>
     {{/sections}}
 </select>

--- a/templates/section_select.mustache
+++ b/templates/section_select.mustache
@@ -36,7 +36,7 @@
     </option>
     {{#sections}}
         <option id="block-massaction-control-section-list-select-option-{{number}}" value="{{number}}">
-            {{title}}
+            {{{title}}}
         </option>
     {{/sections}}
 </select>


### PR DESCRIPTION
Fix the issue https://github.com/Syxton/moodle-block_massaction/issues/103

The issue is that section/activity name can be included special characters (e.g. "&"), but the template adds HTML escapes.