### PR TITLE
Prevent duplicate_task from crashing if course has been deleted in th…

### DIFF
--- a/classes/actions.php
+++ b/classes/actions.php
@@ -137,6 +137,11 @@ class actions {
         }
 
         $courseid = reset($modules)->course;
+        if (!$DB->record_exists('course', ['id' => $courseid])) {
+            debugging('Could not find the course (id ' . $courseid
+                    . '), has probably been deleted before we can duplicate, exiting cleanly.');
+            return;
+        }
 
         // Needed to set the correct context.
         require_login($courseid);
@@ -221,7 +226,7 @@ class actions {
      * @throws moodle_exception
      */
     public static function duplicate_to_course(array $modules, int $targetcourseid, int $sectionnum = -1): void {
-        global $CFG;
+        global $CFG, $DB;
         require_once($CFG->dirroot . '/course/lib.php');
         require_once($CFG->dirroot . '/lib/modinfolib.php');
         if (empty($modules) || !reset($modules)
@@ -229,6 +234,16 @@ class actions {
             return;
         }
         $sourcecourseid = reset($modules)->course;
+        if (!$DB->record_exists('course', ['id' => $sourcecourseid])) {
+            debugging('Could not find the source course (id ' . $sourcecourseid
+                    . '), has probably been deleted before we can duplicate to this course, exiting cleanly.');
+            return;
+        }
+        if (!$DB->record_exists('course', ['id' => $targetcourseid])) {
+            debugging('Could not find the target course (id ' . $targetcourseid
+                    . '), has probably been deleted before we can duplicate to this course, exiting cleanly.');
+            return;
+        }
         $sourcecoursecontext = context_course::instance($sourcecourseid);
         $targetcoursecontext = context_course::instance($targetcourseid);
 


### PR DESCRIPTION
In rare cases when there's a delay in processing adhoc tasks on an instance for example it's possible that a course has already been deleted once the duplicate_task starts to run. In this case the task fails.

This PR introduces a check if the source and target course exists, before actually doing the duplication of activities.