### PR TITLE
repair CI pipeline: renames target mainline Moodle branch.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.1', '8.2', '8.3']
-        moodle-branch: ['master']
+        moodle-branch: ['main']
         database: [pgsql, mariadb]
 
     steps:


### PR DESCRIPTION
the` master` branch is now gone.
for reference, please see: https://moodle.org/mod/forum/discuss.php?d=452551


GHA run: https://github.com/stopfstedt/moodle-block_massaction/actions/runs/11824340971