### PR TITLE
MBS-10766: Prepare for moodle 502

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     services:
       postgres:
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.3', '8.4']
-        moodle-branch: ['main', 'MOODLE_501_STABLE', 'MOODLE_500_STABLE']
+        moodle-branch: ['main', 'MOODLE_502_STABLE']
         database: [pgsql, mariadb]
 
     steps:

--- a/classes/actions.php
+++ b/classes/actions.php
@@ -27,6 +27,7 @@ use context_course;
 use core\event\course_module_updated;
 use core\task\manager;
 use core_course\task\content_notification_task;
+use core_courseformat\formatactions;
 use dml_exception;
 use moodle_exception;
 use require_login_exception;
@@ -174,7 +175,7 @@ class actions {
             }
 
             try {
-                $duplicatedmod = duplicate_module($modinfo->get_course(), $modinfo->get_cm($cmid));
+                $duplicatedmod = formatactions::cm($courseid)->duplicate($cmid);
             } catch (\Exception $e) {
                 $errors[$cmid] = 'cmid:' . $cmid . '(' . $e->getMessage() . ')';
                 $event = \block_massaction\event\course_modules_duplicated_failed::create([
@@ -204,7 +205,7 @@ class actions {
             }
 
             // Move each module to the end of their section.
-            moveto_module($duplicatedmod, $section);
+            formatactions::cm($courseid)->move_end_section($duplicatedmod->id, $section->id);
         }
         $event = \block_massaction\event\course_modules_duplicated::create([
             'context' => \context_course::instance($courseid),
@@ -393,7 +394,7 @@ class actions {
         if ($sectionnum != -1) {
             // A target section has been specified, so we have to move the course modules.
             foreach ($duplicatedmods as $modid) {
-                moveto_module($targetmodinfo->get_cm($modid), $targetsection);
+                formatactions::cm($targetcourseid)->move_end_section($modid, $targetsection->id);
             }
         }
         $event = \block_massaction\event\course_modules_duplicated::create([
@@ -526,8 +527,7 @@ class actions {
      * @throws moodle_exception
      */
     public static function perform_deletion(array $modules): void {
-        global $CFG, $DB;
-        require_once($CFG->dirroot . '/course/lib.php');
+        global $DB;
 
         foreach ($modules as $cm) {
             if (!$cm = get_coursemodule_from_id('', $cm->id, 0, true)) {
@@ -538,15 +538,7 @@ class actions {
                 throw new moodle_exception('invalidcourseid');
             }
 
-            $modlib = $CFG->dirroot . '/mod/' . $cm->modname . '/lib.php';
-
-            if (file_exists($modlib)) {
-                require_once($modlib);
-            } else {
-                new moodle_exception('modulemissingcode', '', '', $modlib);
-            }
-
-            course_delete_module($cm->id, true);
+            formatactions::cm($cm->course)->delete($cm->id, true);
         }
     }
 
@@ -663,7 +655,7 @@ class actions {
             }
 
             // Move each module to the end of their section.
-            moveto_module($cm, $section);
+            formatactions::cm($cm->course)->move_end_section($cm->id, $section->id);
         }
     }
 

--- a/classes/massactionutils.php
+++ b/classes/massactionutils.php
@@ -78,9 +78,9 @@ class massactionutils {
     /**
      * This duplicates a course module to a *different* course.
      *
-     * This function is mainly copied from 'duplicate_module' from /course/lib.php. Unfortunately, it seems that this function
-     * was once intended to also be able to duplicate a module to another course, but mid-function it started to be specific to
-     * the course the source module is part of.
+     * This function is mainly copied from 'duplicate_module' from /course/lib.php which since Moodle 5.2 has moved
+     * to cmactions::duplicate. Unfortunately, it seems that this function was once intended to also be able to duplicate
+     * a module to another course, but mid-function it started to be specific to the course the source module is part of.
      *
      * @param object $course course object.
      * @param object $cm course module object to be duplicated.

--- a/tests/massaction_test.php
+++ b/tests/massaction_test.php
@@ -24,6 +24,7 @@ use block_massaction\hook\filter_sections_different_course;
 use coding_exception;
 use core\event\course_module_updated;
 use core\task\manager;
+use core_courseformat\formatactions;
 use dml_exception;
 use moodle_exception;
 use require_login_exception;
@@ -389,7 +390,8 @@ final class massaction_test extends advanced_testcase {
         $this->assertEquals(1, $module->visibleoncoursepage); // Visible on course page in a visible section.
 
         // Hide section.
-        set_section_visible($this->course->id, $module->sectionnum, 0);
+        $sectioninfo = get_fast_modinfo($this->course)->get_section_info($module->sectionnum);
+        formatactions::section($this->course->id)->set_visibility($sectioninfo, false);
         $module = get_fast_modinfo($this->course)->get_cm($moduleid);
         // After section has been hidden the course module should also be hidden.
         $this->assertEquals(0, $module->visible); // Hidden in a hidden section.
@@ -421,7 +423,8 @@ final class massaction_test extends advanced_testcase {
 
         // Just to doublecheck that a visible section behaves differently.
         // Available modules in visible sections are not visible on course page.
-        set_section_visible($this->course->id, $module->sectionnum, 1);
+        $sectioninfo = get_fast_modinfo($this->course)->get_section_info($module->sectionnum);
+        formatactions::section($this->course->id)->set_visibility($sectioninfo, true);
         actions::set_visibility([$module], true, false);
         $module = get_fast_modinfo($this->course)->get_cm($moduleid);
         $this->assertEquals(1, $module->visible);
@@ -887,21 +890,25 @@ final class massaction_test extends advanced_testcase {
         // Reason: We want to see if the order in the section is preserved which usually is different from the module ids.
         // The method to be tested should follow the sections order. To be able to see the correct effect we have to ensure that
         // the order of moduleids isn't the same as the order in the section.
-        moveto_module(
-            get_fast_modinfo($this->course->id)->get_cm(get_fast_modinfo($this->course->id)->get_sections()[1][0]),
-            get_fast_modinfo($this->course->id)->get_section_info(1)
+        $modinfo = get_fast_modinfo($this->course->id);
+        formatactions::cm($this->course->id)->move_end_section(
+            $modinfo->get_sections()[1][0],
+            $modinfo->get_section_info(1)->id
         );
-        moveto_module(
-            get_fast_modinfo($this->course->id)->get_cm(get_fast_modinfo($this->course->id)->get_sections()[1][3]),
-            get_fast_modinfo($this->course->id)->get_section_info(1)
+        $modinfo = get_fast_modinfo($this->course->id);
+        formatactions::cm($this->course->id)->move_end_section(
+            $modinfo->get_sections()[1][3],
+            $modinfo->get_section_info(1)->id
         );
-        moveto_module(
-            get_fast_modinfo($this->course->id)->get_cm(get_fast_modinfo($this->course->id)->get_sections()[3][0]),
-            get_fast_modinfo($this->course->id)->get_section_info(3)
+        $modinfo = get_fast_modinfo($this->course->id);
+        formatactions::cm($this->course->id)->move_end_section(
+            $modinfo->get_sections()[3][0],
+            $modinfo->get_section_info(3)->id
         );
-        moveto_module(
-            get_fast_modinfo($this->course->id)->get_cm(get_fast_modinfo($this->course->id)->get_sections()[3][3]),
-            get_fast_modinfo($this->course->id)->get_section_info(3)
+        $modinfo = get_fast_modinfo($this->course->id);
+        formatactions::cm($this->course->id)->move_end_section(
+            $modinfo->get_sections()[3][3],
+            $modinfo->get_section_info(3)->id
         );
     }
 

--- a/version.php
+++ b/version.php
@@ -24,9 +24,9 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2025102700;
-$plugin->requires  = 2023100900;
+$plugin->version = 2026042700;
+$plugin->requires  = 2024042000;
 $plugin->component = 'block_massaction';
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = 'v7.5.1';
-$plugin->supported = [500, 501];
+$plugin->release = 'v8.0.0';
+$plugin->supported = [502, 502];


### PR DESCRIPTION
Closes #144 

There are a few deprecations regarding the course module actions we were using before which now have been moved to the formatactions class. Nothing too special, they have been moved and renamed mainly.

However, it would be a bit complicated to keep compatibility with older branches, so I suggest to split off a branch MOODLE_501_STABLE from the current main before merging this.

In this branch I updated version.php and GHA actions config to be only compatible with Moodle 5.2 which then should be the new master branch.

@Syxton Please review and eventually merge. TIA!